### PR TITLE
Add configurations to ignore node modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Scripts used to migrate Figma's codebase to strictNullChecks",
   "scripts": {
-    "find-candidates": "tsc && node src/findCandidates.js",
+    "find-candidates": "tsc && node --trace-warnings src/findCandidates.js",
     "auto-add": "tsc && node src/autoAdd.js",
     "find-cycles": "tsc && node src/runFindCycles.js",
     "visualize": "tsc && node src/visualize.js"

--- a/src/findCandidates.ts
+++ b/src/findCandidates.ts
@@ -27,7 +27,11 @@ async function findCandidates() {
 
   const fileToImports = new Map<string, string[]>();
   for (const file of await forEachFileInSrc(srcRoot)) {
-    fileToImports.set(file, getImportsForFile(file, srcRoot))
+    if(!file.includes('node_modules')) {
+      fileToImports.set(file, getImportsForFile(file, srcRoot));
+    } else {
+      console.log(file)
+    }
   }
 
   const fileToImportsSecondOrder = oneLevelDownImports(fileToImports)

--- a/src/findCandidates.ts
+++ b/src/findCandidates.ts
@@ -29,8 +29,6 @@ async function findCandidates() {
   for (const file of await forEachFileInSrc(srcRoot)) {
     if(!file.includes('node_modules')) {
       fileToImports.set(file, getImportsForFile(file, srcRoot));
-    } else {
-      console.log(file)
     }
   }
 

--- a/src/findCycles.ts
+++ b/src/findCycles.ts
@@ -14,7 +14,7 @@ export function findCycles(srcRoot: string, files: string[]): string[][] {
 
   // Step 1: do a post-order traversal of the dependency tree
   const visit = (file: string) => {
-    if (!imports.has(file)) {
+    if (!imports.has(file) && !file.includes('node_modules')) {
       const importList = getImportsForFile(file, srcRoot)
       imports.set(file, importList)
 

--- a/src/tsHelper.ts
+++ b/src/tsHelper.ts
@@ -19,8 +19,6 @@ export function getImportsForFile(file: string, srcRoot: string) {
       } else {
         throw new Error(`Warning: Importing a directory without an index.ts file: ${path.relative(srcRoot, file)}`)
       }
-    } else {
-      return;
     }
   }
 

--- a/src/tsHelper.ts
+++ b/src/tsHelper.ts
@@ -10,13 +10,17 @@ export function getImportsForFile(file: string, srcRoot: string) {
   file = fs.realpathSync(file)
 
   if (fs.lstatSync(file).isDirectory()) {
-    const index = path.join(file, "index.ts")
-    if (fs.existsSync(index)) {
-      // https://basarat.gitbooks.io/typescript/docs/tips/barrel.html
-      console.warn(`Warning: Barrel import: ${path.relative(srcRoot, file)}`)
-      file = index
+    if(!file.includes('node_modules')) {
+      const index = path.join(file, "index.ts")
+      if (fs.existsSync(index)) {
+        // https://basarat.gitbooks.io/typescript/docs/tips/barrel.html
+        console.warn(`Warning: Barrel import: ${path.relative(srcRoot, file)}`)
+        file = index
+      } else {
+        throw new Error(`Warning: Importing a directory without an index.ts file: ${path.relative(srcRoot, file)}`)
+      }
     } else {
-      throw new Error(`Warning: Importing a directory without an index.ts file: ${path.relative(srcRoot, file)}`)
+      return;
     }
   }
 
@@ -63,8 +67,13 @@ export class ImportTracker {
     if (this.imports.has(file)) {
       return this.imports.get(file)
     }
-    const imports = getImportsForFile(file, this.srcRoot)
-    this.imports.set(file, imports)
+
+    let imports = [];
+    if(!file.includes('node_modules')) {
+      imports = getImportsForFile(file, this.srcRoot)
+      this.imports.set(file, imports)
+    }
+
     return imports
   }
 }


### PR DESCRIPTION
For some reason, the exclude pattern in the mx-app tsconfig files is not being read. Rather than going through the code and figuring out the inner workings, I've added this quickfix to get our work on the go. This can be revisited in the future if we plan to keep using this functionality. 